### PR TITLE
Improve HTTPoison dialyzer spec

### DIFF
--- a/lib/cookie_jar/spec_utils.ex
+++ b/lib/cookie_jar/spec_utils.ex
@@ -3,11 +3,11 @@ defmodule CookieJar.SpecUtils do
     parameters =
       if body do
         quote do
-          [GenServer.server(), String.t(), any, Keyword.t(), Keyword.t()]
+          [GenServer.server(), String.t(), any, HTTPoison.headers(), HTTPoison.options()]
         end
       else
         quote do
-          [GenServer.server(), String.t(), Keyword.t(), Keyword.t()]
+          [GenServer.server(), String.t(), HTTPoison.headers(), HTTPoison.options()]
         end
       end
 


### PR DESCRIPTION
In an HTTPoison request the arguments that correspond to the header and to the options have more permissive typing than Keyword.t().

Header can be a list of `{binary(), binary()}` types and not just `{atom{}, binary()}` as a Keyword list would expect. This is important when dealing with header keys that cannot be atomised, such as `X-Requested-With`. The [HTTPoison header type](https://hexdocs.pm/httpoison/HTTPoison.Request.html#t:headers/0) is ideally permissive.

I included `HTTPoison.options()` type for completeness. 